### PR TITLE
Id/#1 Add a .gitattribute file for .lua and AviUtl .anm scripts.

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,2 @@
+*.lua text eol=crlf working-tree-encoding=cp932
+*.anm text eol=crlf working-tree-encoding=cp932 linguist-language=Lua


### PR DESCRIPTION
# Id/#1 Add a .gitattribute file for .lua and AviUtl .anm scripts.
## Overview
Add a .gitattribute file for .lua and AviUtl .anm scripts.
This will change the eol,encoding and linguist-language settings on them.

## Purpose
This pull request refines an issue where the eol and encoding of AviUtl scripts conflict with git's default settings for them.
And AviUtl .anm file is based on Lua so I need to set the linguist-language setting to Lua. 

## Changes
- [x] Set the eol on .lua and .anm to crlf
- [x] Set the encoding on .lua and .anm to cp932
- [x] Set the linguist-language on .anm to Lua
